### PR TITLE
Change the way of specifying jar versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -186,4 +186,12 @@ task wrapper(type: Wrapper) {
 // For LinkedIn internal builds, apply the LinkedIn-specific build file
 if (project.hasProperty('overrideBuildEnvironment')) {
   apply from: project.overrideBuildEnvironment
+} else {
+  // Specify Jar versions here instead of within gradle.properties
+  // This will provide overriding ability for internal builds
+  subprojects {
+    tasks.withType(Jar) {
+      version '1.0.0'
+    }
+  }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,3 @@
-# Current version
-version=1.0.0
-
 # long-running Gradle process speeds up local builds
 # to stop the daemon run './gradlew --stop'
 org.gradle.daemon=true


### PR DESCRIPTION
The old way makes it very hard to override the jar versions in internal builds. (gradle.properties is not so easy to be overridden) in scripts. Tested with the current change that I could override the versions with other numbers.